### PR TITLE
docs: focus README on learning planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,296 +1,54 @@
-# F1TENTH Autonomous Racing System
+# 학습 기반 플래너 안내
 
-This repository contains a complete F1TENTH autonomous racing system with localization, path planning, and path following capabilities. The system supports both real car deployment and simulation environments.
+이 저장소는 F1TENTH 자율주행 차량을 위한 PyTorch 기반 학습 플래너 예제를 제공합니다.
+기존 README에 있던 규칙 기반(라티스 플래너, Follow-The-Gap 등) 내용은 제거되었으며,
+학습 기반 플래너 실행에 필요한 절차만을 정리했습니다.
 
-## System Architecture
-
-The autonomous racing system provides two navigation approaches:
-
-### Option 1: Full Autonomous Racing System
-Four main components launched in sequence:
-
-1. **Localization** - Particle filter for robot pose estimation
-2. **F1TENTH System** - Hardware interface (real car) or Simulation bridge 
-3. **Path Planning** - Lattice planner for trajectory generation
-4. **Path Following** - Controller to execute planned trajectories
-
-### Option 2: Reactive Navigation (Simple)
-Basic obstacle avoidance using only LiDAR:
-
-1. **F1TENTH System** - Hardware interface or Simulation bridge
-2. **Follow the Gap** - Reactive LiDAR-only navigation
-
-## Installation
-
-### Clone Repository
-
-This repository uses submodules, so clone with recursive flag:
+## 준비
 
 ```bash
-# Clone with submodules
+# 저장소 클론 (서브모듈 포함)
 git clone --recursive <repository-url>
-cd f1tenth_all_js
-
-# If already cloned without submodules, initialize them:
-git submodule update --init --recursive
+cd learning_all_js
 ```
 
-### Update Repository
-
-To pull latest changes including submodules:
+## 빌드
 
 ```bash
-# Pull main repository and all submodules
-git pull --recurse-submodules
-
-# Alternative method:
-git pull
-git submodule update --remote --recursive
-```
-
-### Build Workspace
-
-```bash
-# Build the workspace
 colcon build
 source install/setup.bash
 ```
 
-## Usage Instructions
+## 실행 순서
 
-### Option A: Full Autonomous Racing System
+### 1. PolarGrid 생성 노드
+전역 경로를 PolarGrid 형태로 변환합니다.
 
-#### Step 1: Launch Localization (Particle Filter)
-
-Choose the appropriate localization mode:
-
-#### For Real Car (Default)
 ```bash
-ros2 launch particle_filter_cpp localize_launch.py
+ros2 run global_to_polar_cpp global_to_polar_node \
+  --ros-args -p path_csv_file:=<전역경로 CSV>
 ```
 
-#### For SLAM Map Mode (Real Car)
+### 2. 학습 플래너 노드
+사전 학습된 PyTorch 모델을 이용해 로컬 경로를 생성합니다.
+
 ```bash
-ros2 launch particle_filter_cpp localize_slam_launch.py
+ros2 run pytorch_planner_pkg planner_node \
+  --ros-args -p model_path:=src/pytorch_planner_pkg/model/mobilenet_trained_updated.pt
 ```
 
-#### For Simulation
-```bash
-ros2 launch particle_filter_cpp localize_sim_launch.py
-```
+노드는 `/scan`과 `/polar_grid` 토픽을 구독하고,
+`/planned_path_with_velocity` 토픽으로 16개의 웨이포인트를 발행합니다.
 
-### Step 2: Launch F1TENTH System or Simulation
+## 주요 토픽
 
-#### For Real Car
-```bash
-ros2 launch f1tenth_stack bringup_launch.py
-```
+| 토픽 | 타입 | 설명 |
+|------|------|------|
+| `/scan` | `sensor_msgs/LaserScan` | LIDAR 스캔 데이터 |
+| `/polar_grid` | `global_to_polar_cpp/PolarGrid` | 전역 경로를 PolarGrid로 표현한 데이터 |
+| `/planned_path_with_velocity` | `f1tenth_planning_custom_msgs/PathWithVelocity` | 학습 플래너가 생성한 경로 및 속도 |
 
-#### For Simulation
-```bash
-ros2 launch f1tenth_gym_ros gym_bridge_launch.py
-```
+## 모델
 
-### Step 3: Set Initial Pose
-
-After launching the localization system:
-
-1. Open RViz (should launch automatically with localization)
-2. Click the **"2D Pose Estimate"** button in RViz toolbar
-3. Click and drag on the map to set the robot's initial position and orientation
-4. Verify that the particle cloud converges around the robot's actual position
-
-### Step 4: Launch Path Planner (Lattice Planner)
-
-#### For Real Car (Default - SLAM map mode)
-```bash
-ros2 launch lattice_planner_pkg lattice_planner.launch.py
-```
-
-#### For Simulation
-```bash
-ros2 launch lattice_planner_pkg lattice_planner.launch.py sim_mode:=true
-```
-
-### Step 5: Launch Path Follower
-
-#### For Real Car
-```bash
-ros2 launch path_follower_pkg path_follower.launch.py sim_mode:=false
-```
-
-#### For Simulation
-```bash
-ros2 launch path_follower_pkg path_follower.launch.py sim_mode:=true
-```
-
-### Option B: Reactive Navigation (Simple)
-
-For basic obstacle avoidance without localization or planning:
-
-#### For Real Car
-```bash
-# Terminal 1: Hardware interface
-ros2 launch f1tenth_stack bringup_launch.py
-
-# Terminal 2: Reactive navigation
-ros2 run gap_follow reactive_node
-```
-
-#### For Simulation
-```bash
-# Terminal 1: Simulation environment  
-ros2 launch f1tenth_gym_ros gym_bridge_launch.py
-
-# Terminal 2: Reactive navigation
-ros2 run gap_follow reactive_node
-```
-
-**Advantages:**
-- No localization or mapping required
-- Fast setup and testing
-- Real-time reactive obstacle avoidance
-- Works in unknown environments
-
-**Use Cases:**
-- Quick testing and demos
-- Learning F1TENTH basics
-- Simple navigation tasks
-- Fallback when full system fails
-
-## Launch Parameters
-
-### Particle Filter Parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `map_name` | Auto-detected | Map file name (without .yaml extension) |
-| `scan_topic` | `/scan` | Laser scan topic |
-| `odom_topic` | `/odom` (real), `/ego_racecar/odom` (sim) | Odometry topic |
-| `use_rviz` | `true` | Launch RViz visualization |
-| `use_sim_time` | `false` | Use simulation time |
-
-### Lattice Planner Parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `sim_mode` | `false` | Use simulation topics if true |
-| `use_sim_time` | `false` | Use simulation time |
-
-### Path Follower Parameters
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `sim_mode` | `true` | Use simulation topics if true |
-
-## Topic Remapping
-
-### Real Car Mode
-- Odometry: `/pf/pose/odom` (from particle filter)
-- Laser: `/scan`
-- Drive commands: `/drive`
-
-### Simulation Mode  
-- Odometry: `/ego_racecar/odom` (from F1TENTH Gym)
-- Laser: `/scan`
-- Drive commands: `/drive`
-
-## Configuration Files
-
-### Localization Configs
-- `src/particle_filter_cpp/config/localize.yaml` - Real car settings
-- `src/particle_filter_cpp/config/localize_slam.yaml` - SLAM map settings  
-- `src/particle_filter_cpp/config/localize_sim.yaml` - Simulation settings
-
-### Planning & Control Configs
-- `src/lattice_planner_f1tenth/config/planner_config.yaml` - Path planning parameters
-- `src/lattice_path_follower_f1tenth/config/path_follower_config.yaml` - Control parameters
-
-### Maps
-- `src/particle_filter_cpp/maps/` - Map files (.png/.pgm and .yaml)
-- `src/f1tenth_gym_ros/maps/` - Simulation maps
-
-## Example Launch Sequences
-
-### Real Car with SLAM Map
-```bash
-# Terminal 1: Localization with SLAM map
-ros2 launch particle_filter_cpp localize_slam_launch.py
-
-# Terminal 2: F1TENTH hardware interface  
-ros2 launch f1tenth_stack bringup_launch.py
-
-# Terminal 3: Set initial pose in RViz, then launch planner
-ros2 launch lattice_planner_pkg lattice_planner.launch.py
-
-# Terminal 4: Launch path follower
-ros2 launch path_follower_pkg path_follower.launch.py sim_mode:=false
-```
-
-### Simulation Mode
-```bash
-# Terminal 1: Localization for simulation
-ros2 launch particle_filter_cpp localize_sim_launch.py
-
-# Terminal 2: F1TENTH Gym simulation
-ros2 launch f1tenth_gym_ros gym_bridge_launch.py
-
-# Terminal 3: Set initial pose in RViz, then launch planner  
-ros2 launch lattice_planner_pkg lattice_planner.launch.py sim_mode:=true
-
-# Terminal 4: Launch path follower
-ros2 launch path_follower_pkg path_follower.launch.py sim_mode:=true
-```
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Particle filter not converging**: Ensure initial pose is set correctly using RViz 2D Pose Estimate
-2. **No laser data**: Check that scan topics match between localization and hardware/simulation
-3. **Planning failures**: Verify that localization is working and pose estimates are stable
-4. **Simulation not starting**: Ensure F1TENTH Gym dependencies are installed
-
-### Debug Topics
-
-Monitor these topics for debugging:
-- `/scan` - Laser scan data
-- `/odom` or `/ego_racecar/odom` - Odometry data  
-- `/pf/pose/odom` - Particle filter pose estimate
-- `/planned_path` - Generated trajectories
-- `/drive` - Drive commands
-
-## Dependencies
-
-- ROS 2 (Humble/Iron)
-- Navigation2 stack
-- F1TENTH Gym (for simulation)
-- RViz2
-- Custom packages included in this workspace
-
-## Package Structure
-
-```
-src/
-├── f1tenth_base_setup/              # F1TENTH hardware drivers and configs
-├── f1tenth_gym_ros/                 # F1TENTH Gym simulation bridge  
-├── particle_filter_cpp/             # Localization system
-├── lattice_planner_f1tenth/         # Path planning algorithms  
-├── lattice_path_follower_f1tenth/   # Path following control
-├── basecode_follow_the_gap/         # Reactive LiDAR-only navigation
-└── f1tenth_planning_custom_msgs/    # Custom message definitions
-```
-
-### Navigation Approaches
-
-**Full System (Competition Ready):**
-- Advanced localization with particle filter
-- Optimal path planning with lattice planner
-- Precise trajectory following control
-- Best for racing performance
-
-**Reactive System (Simple & Fast):**
-- LiDAR-only obstacle avoidance
-- No localization or mapping required  
-- Real-time reactive navigation
-- Best for learning and quick testing
+사전 학습된 모델 파일은 `src/pytorch_planner_pkg/model` 폴더에 포함되어 있으며,
+다른 모델로 교체하거나 재학습한 모델을 사용하려면 `model_path` 파라미터를 수정하면 됩니다.


### PR DESCRIPTION
## Summary
- Clarified that the project documents only the PyTorch learning-based planner
- Updated build and run steps for the global_to_polar and planner nodes
- Added notes on pretrained model usage

## Testing
- `colcon test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32d4b3fb48320a8526c58f0bb55ef